### PR TITLE
Enable dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,19 @@
 
 version: 2
 updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: sunday
+    open-pull-requests-limit: 20
+    assignees:
+      - johnnymetz
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
       day: sunday
-      time: "08:42"
-      timezone: Etc/UTC
     open-pull-requests-limit: 20
+    assignees:
+      - johnnymetz


### PR DESCRIPTION
- Use dependabot to update npm dependencies to ensure we're up-to-date