### PR TITLE
Drop ESLINT_NO_IMPORTS

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,14 +315,4 @@ config.overrides.push({
 	},
 });
 
-if (process.env.ESLINT_NO_IMPORTS) {
-	const importRules = Object.keys(require("eslint-plugin-import").rules);
-	config.overrides.push({
-		files: ["**"],
-		rules: Object.fromEntries(
-			importRules.map((rule) => [`import/${rule}`, "off"])
-		),
-	});
-}
-
 module.exports = config;

--- a/index.js
+++ b/index.js
@@ -316,20 +316,13 @@ config.overrides.push({
 });
 
 if (process.env.ESLINT_NO_IMPORTS) {
-	for (const key of Object.keys(config.rules)) {
-		if (key.startsWith("import/")) {
-			delete config.rules[key];
-		}
-	}
-
-	const list = new Set(config.extends);
-	for (const plugin of list) {
-		if (plugin.startsWith("plugin:import/")) {
-			list.delete(plugin);
-		}
-	}
-
-	config.extends = [...list];
+	const importRules = Object.keys(require("eslint-plugin-import").rules);
+	config.overrides.push({
+		files: ["**"],
+		rules: Object.fromEntries(
+			importRules.map((rule) => [`import/${rule}`, "off"])
+		),
+	});
 }
 
 module.exports = config;


### PR DESCRIPTION
`eslint-plugin-import` is super slow and we added the ESLINT_NO_IMPORTS env to skip those rules, but it's been broken. The code just dropped the local rule config but did nothing against the rules in `eslint-config-xo-typescript`, so it had the opposite effect.

I tried configuring it properly by setting an override for every file, disabling every rule, 195fb67f0fe72a2379b4edfa31150d4818a3ddb7 but the linting still takes 5m16s.

Example usage:

```
ESLINT_NO_IMPORTS=1 npx eslint src --ext js,jsx,ts,tsx --quiet
```