### PR TITLE
Forbid `isDevToolsPage` check

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,11 @@ const config = {
 						importNames: ["Form"],
 						message: 'Use this instead: import "@/components/form/Form"',
 					},
+					{
+						group: ["webext-detect-page"],
+						importNames: ["isDevToolsPage"],
+						message: 'Use this instead: import { isPageEditor } from "@/utils/expectContext";',
+					},
 				],
 			},
 		],


### PR DESCRIPTION
See https://github.com/pixiebrix/pixiebrix-extension/pull/7378/files#r1460159237

> it specifically and exclusively targets the page specified in the manifest as `devtools_page`, not "any devtools page". 
> 
> For our intents, the method should probably be banned via eslint since our `devtools_page` has 3 lines of code.