### PR TITLE
Adding rule for blocking importing lodash.lowerCase

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,11 @@ const config = {
 			"error",
 			{
 				// Documentation: https://eslint.org/docs/rules/no-restricted-imports#options
+				paths: [{
+					name: "lodash",
+					importNames: ["lowerCase"],
+					message: "Use the native String.toLowerCase method instead."
+				}],
 				patterns: [
 					{
 						group: ["*/__mocks__/*"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-pixiebrix",
-	"version": "0.32.1",
+	"version": "0.33.1",
 	"description": "ESLint shareable config for PixieBrix",
 	"repository": "pixiebrix/eslint-config-pixiebrix",
 	"license": "MIT",


### PR DESCRIPTION
This adds a rule to prevent us from using lodash lowerCase which has some weird behavior with splitting a camelCased word.