### PR TITLE
Turn `use-sync-external-store` runtime error into lint error

### DIFF
--- a/fixtures.ts
+++ b/fixtures.ts
@@ -1,7 +1,10 @@
-/** 
- * @file File that verifies local rules. 
+/**
+ * @file File that verifies local rules.
  * Each line MUST be preceded by `eslint-disable-next-line`, unless it's the "valid" version
  */
 
+// @ts-expect-error -- Testing eslint only
+// eslint-disable-next-line no-restricted-imports
 import { useSyncExternalStore } from "use-sync-external-store";
-import { useSyncExternalStore } from "use-sync-external-store/shim"; /* Valid */
+// @ts-expect-error -- Testin eslint only
+import { useSyncExternalStore as xx } from "use-sync-external-store/shim"; /* Valid */

--- a/fixtures.ts
+++ b/fixtures.ts
@@ -3,6 +3,5 @@
  * Each line MUST be preceded by `eslint-disable-next-line`, unless it's the "valid" version
  */
 
-// eslint-disable-next-line no-restricted-imports
 import { useSyncExternalStore } from "use-sync-external-store";
 import { useSyncExternalStore } from "use-sync-external-store/shim"; /* Valid */

--- a/fixtures.ts
+++ b/fixtures.ts
@@ -1,0 +1,8 @@
+/** 
+ * @file File that verifies local rules. 
+ * Each line MUST be preceded by `eslint-disable-next-line`, unless it's the "valid" version
+ */
+
+// eslint-disable-next-line no-restricted-imports
+import { useSyncExternalStore } from "use-sync-external-store";
+import { useSyncExternalStore } from "use-sync-external-store/shim"; /* Valid */

--- a/index.js
+++ b/index.js
@@ -83,6 +83,11 @@ const config = {
 							"Use the local <Loader/> component instead, it's already centered.",
 					},
 					{
+						group: ["use-sync-external-store", "!use-sync-external-store/shim"],
+						message:
+							"In React 17, import \"use-sync-external-store/shim\", not \"use-sync-external-store\".",
+					},
+					{
 						group: ["react-bootstrap/*", "!react-bootstrap/types"],
 						message:
 							'You can import "react-bootstrap" instead of "react-bootstrap/*".',

--- a/index.js
+++ b/index.js
@@ -57,11 +57,13 @@ const config = {
 			"error",
 			{
 				// Documentation: https://eslint.org/docs/rules/no-restricted-imports#options
-				paths: [{
-					name: "lodash",
-					importNames: ["lowerCase"],
-					message: "Use the native String.toLowerCase method instead."
-				}],
+				paths: [
+					{
+						name: "lodash",
+						importNames: ["lowerCase"],
+						message: "Use the native String.toLowerCase method instead.",
+					},
+				],
 				patterns: [
 					{
 						group: ["*/__mocks__/*"],
@@ -84,8 +86,9 @@ const config = {
 					},
 					{
 						group: ["use-sync-external-store", "!use-sync-external-store/shim"],
+						importNames: ["useSyncExternalStore"],
 						message:
-							"In React 17, import \"use-sync-external-store/shim\", not \"use-sync-external-store\".",
+							'In React 17, import "use-sync-external-store/shim", not "use-sync-external-store".',
 					},
 					{
 						group: ["react-bootstrap/*", "!react-bootstrap/types"],
@@ -110,7 +113,8 @@ const config = {
 					{
 						group: ["webext-detect-page"],
 						importNames: ["isDevToolsPage"],
-						message: 'Use this instead: import { isPageEditor } from "@/utils/expectContext";',
+						message:
+							'Use this instead: import { isPageEditor } from "@/utils/expectContext";',
 					},
 				],
 			},

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 		"xoPluginsConfig.js"
 	],
 	"scripts": {
-		"fix": "eslint . --fix",
-		"test": "eslint ."
+		"fix": "npm test -- --fix",
+		"test": "eslint . --ext .js,.jsx,.ts,.tsx"
 	},
 	"dependencies": {
 		"@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"include": [".*.js", "*.js"]
+	"include": [".*.js", "*.js", "*.ts"]
 }


### PR DESCRIPTION
I just saw this error in the console.

The linter can make sure this error will be seen before it makes it into the repo by mistake (unlikely, but it's an easy lint here)

<img width="829" alt="Screenshot 17" src="https://github.com/pixiebrix/eslint-config-pixiebrix/assets/1402241/a90cfb9f-1eed-4c26-82ac-e94f7b203236">
