### PR TITLE
Drop `no-restricted-paths` exception

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -21,9 +21,6 @@ module.exports = {
 		"@typescript-eslint/no-unsafe-return": "off",
 		"@typescript-eslint/no-non-null-assertion": "off",
 
-		// Tests can import any file
-		"import/no-restricted-paths": "off",
-
 		// Common and required usage in tests
 		"unicorn/no-useless-undefined": "off",
 


### PR DESCRIPTION
- Follows https://github.com/pixiebrix/pixiebrix-extension/pull/7593

It shouldn't be here in the first place, the rule is only part of the extension