### PR TITLE
`@typescript-eslint/restrict-template-expressions`: Allow never

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,10 @@ const config = {
 				delete config.types.null;
 			}
 		),
+		"@typescript-eslint/restrict-template-expressions": [
+			"error",
+			{ allowNever: true, allowNumber: true },
+		],
 		"@typescript-eslint/no-non-null-assertion": "error",
 		"@typescript-eslint/no-explicit-any": [
 			"error",


### PR DESCRIPTION
Previous config:

- https://github.com/xojs/eslint-config-xo-typescript/blob/c8d272b40e48a4f669d1e42cf395eafd4f068a8c/index.js#L629C23-L634

Preparing for:

- https://github.com/pixiebrix/pixiebrix-extension/pull/7703