### PR TITLE
Revert "Remove redundant typescript dependencies"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.36.1",
 			"license": "MIT",
 			"dependencies": {
+				"@typescript-eslint/eslint-plugin": "^7.0.2",
+				"@typescript-eslint/parser": "^7.0.2",
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-config-xo": "^0.44.0",
 				"eslint-config-xo-typescript": "^3.0.0",
@@ -406,7 +408,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.0.2.tgz",
 			"integrity": "sha512-/XtVZJtbaphtdrWjr+CJclaCVGPtOdBpFEnvtNf/jRV0IiEemRrL0qABex/nEt8isYcnFacm3nPHYQwL+Wb7qg==",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
 				"@typescript-eslint/scope-manager": "7.0.2",
@@ -441,7 +442,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.0.2.tgz",
 			"integrity": "sha512-GdwfDglCxSmU+QTS9vhz2Sop46ebNCXpPPvsByK7hu0rFGRHL+AusKQJ7SoN+LbLh6APFpQwHKmDSwN35Z700Q==",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "7.0.2",
 				"@typescript-eslint/types": "7.0.2",
@@ -469,7 +469,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.0.2.tgz",
 			"integrity": "sha512-l6sa2jF3h+qgN2qUMjVR3uCNGjWw4ahGfzIYsCtFrQJCjhbrDPdiihYT8FnnqFwsWX+20hK592yX9I2rxKTP4g==",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "7.0.2",
 				"@typescript-eslint/visitor-keys": "7.0.2"
@@ -486,7 +485,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.0.2.tgz",
 			"integrity": "sha512-IKKDcFsKAYlk8Rs4wiFfEwJTQlHcdn8CLwLaxwd6zb8HNiMcQIFX9sWax2k4Cjj7l7mGS5N1zl7RCHOVwHq2VQ==",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/typescript-estree": "7.0.2",
 				"@typescript-eslint/utils": "7.0.2",
@@ -513,7 +511,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.0.2.tgz",
 			"integrity": "sha512-ZzcCQHj4JaXFjdOql6adYV4B/oFOFjPOC9XYwCaZFRvqN8Llfvv4gSxrkQkd2u4Ci62i2c6W6gkDwQJDaRc4nA==",
-			"peer": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
 			},
@@ -526,7 +523,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.0.2.tgz",
 			"integrity": "sha512-3AMc8khTcELFWcKcPc0xiLviEvvfzATpdPj/DXuOGIdQIIFybf4DMT1vKRbuAEOFMwhWt7NFLXRkbjsvKZQyvw==",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "7.0.2",
 				"@typescript-eslint/visitor-keys": "7.0.2",
@@ -554,7 +550,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.0.2.tgz",
 			"integrity": "sha512-PZPIONBIB/X684bhT1XlrkjNZJIEevwkKDsdwfiu1WeqBxYEEdIgVDgm8/bbKHVu+6YOpeRqcfImTdImx/4Bsw==",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
@@ -579,7 +574,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.0.2.tgz",
 			"integrity": "sha512-8Y+YiBmqPighbm5xA2k4wKTxRzx9EkBu7Rlw+WHqMvRJ3RPz/BMBO9b2ru0LUNmXg120PHUXD5+SWFy2R8DqlQ==",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "7.0.2",
 				"eslint-visitor-keys": "^3.4.1"
@@ -862,7 +856,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -3507,7 +3500,6 @@
 			"version": "9.0.3",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
 			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -4461,7 +4453,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
 			"integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
-			"peer": true,
 			"engines": {
 				"node": ">=16"
 			},

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"test": "eslint ."
 	},
 	"dependencies": {
+		"@typescript-eslint/eslint-plugin": "^7.0.2",
+		"@typescript-eslint/parser": "^7.0.2",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-config-xo": "^0.44.0",
 		"eslint-config-xo-typescript": "^3.0.0",


### PR DESCRIPTION
Reverts pixiebrix/eslint-config-pixiebrix#226


Nope, they're needed

```
Oops! Something went wrong! :(

ESLint: 8.56.0

ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin".

(The package "@typescript-eslint/eslint-plugin" was not found when loaded as a Node module from the directory "./pixiebrix-extension".)

It's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm install @typescript-eslint/eslint-plugin@latest --save-dev

The plugin "@typescript-eslint/eslint-plugin" was referenced from the config file in ".eslintrc.js » eslint-config-pixiebrix » eslint-config-xo-typescript".

If you still can't figure out the problem, please stop by https://eslint.org/chat/help to chat with the team.
```