### PR TITLE
Reduce dependabot frequency to monthly 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
       day: sunday
     open-pull-requests-limit: 20
     assignees:
@@ -18,7 +18,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
       day: sunday
     open-pull-requests-limit: 20
     assignees:


### PR DESCRIPTION
This package doesn't need to be updated _that_ often