### PR TITLE
Require assertions in jest tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,6 @@ const config = {
 		"@shopify/react-hooks-strict-return": "error",
 		"@shopify/prefer-module-scope-constants": "error",
 
-		"jest/expect-expect": "error",
-
 		"no-restricted-imports": ["error", require("./no-restricted-imports")],
 		"no-restricted-syntax": ["error", ...require("./no-restricted-syntax")],
 		"no-mixed-operators": [

--- a/index.js
+++ b/index.js
@@ -32,6 +32,8 @@ const config = {
 		"@shopify/react-hooks-strict-return": "error",
 		"@shopify/prefer-module-scope-constants": "error",
 
+		"jest/expect-expect": "error",
+
 		"no-restricted-imports": ["error", require("./no-restricted-imports")],
 		"no-restricted-syntax": ["error", ...require("./no-restricted-syntax")],
 		"no-mixed-operators": [

--- a/tests.js
+++ b/tests.js
@@ -18,6 +18,8 @@ module.exports = {
 	rules: {
 		// Enable more testing rules
 		"jest/prefer-expect-resolves": "error",
+		"jest/expect-expect": "error",
+
 		"@shopify/jest-no-snapshots": "warn",
 
 		// Loosen types a bit to facilitate testing


### PR DESCRIPTION
* The [expect-expect](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/expect-expect.md) rule from the jest plugin recommended preset only warns on missing assertions
